### PR TITLE
Allow test file path to be specified via args

### DIFF
--- a/tasks/mocha_parallel.js
+++ b/tasks/mocha_parallel.js
@@ -7,10 +7,12 @@ module.exports = function (grunt) {
   /**
    * Enumerate and return the top-level suite names.
    */
-  function getTopLevelSuiteNames(mocha, callback) {
+  function getTopLevelSuiteNames(options, callback) {
+    var mocha = options.mocha;
     var enumerate_ui = path.resolve(__dirname, 'helpers', 'enumerate_ui.js');
-    var command = mocha + ' -u ' + enumerate_ui;
-    var enumerate = child_process.exec(command, function(code, stdout, stderr) {
+    var command = mocha + ' -u ' + enumerate_ui + ' ' + (options.args() || []).join(' ');
+
+    var enumerate = child_process.exec(command, function (code, stdout, stderr) {
       var names = stderr.replace(/^\s+|\s+$/g, '').split('\n');
       callback(names);
     });
@@ -141,7 +143,7 @@ module.exports = function (grunt) {
       concurrency: os.cpus().length * 1.5
     });
 
-    getTopLevelSuiteNames(options.mocha, function(names) {
+    getTopLevelSuiteNames(options, function(names) {
       runSkippedTests(options, function() {
         runTestsInParallel(names, options, done);
       });


### PR DESCRIPTION
When the test files not in the default folder expected by Mocha (/test) then tests are not found. There is a way to work this around by specifying the path in the args config. However the parameters passed in there are used only when mocha is executed in the runMocha function but not when executed to get the suite names. The PR is to fix this.
There is an open issue on the project on this subject. 